### PR TITLE
Allow users to save webhooks against their accounts

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -13,11 +13,13 @@ class Subscription(Base):
     __tablename__ = 'subscription'
     id = Column(String, primary_key=True, default=uuid.uuid4)
     email = Column(String)
+    webhook = Column(String)
     account = Column(String, nullable=False)
 
-    def __init__(self, email, account):
+    def __init__(self, email, webhook, account):
         self.id = str(uuid.uuid4())
         self.email = email
+        self.webhook = webhook
         self.account = account
 
 
@@ -25,10 +27,12 @@ class User(Base):
     __tablename__ = 'user'
     email = Column(String, primary_key=True)
     password = Column(String, nullable=False)
+    webhook = Column(String)
 
-    def __init__(self, email, password):
+    def __init__(self, email, password, webhook=None):
         self.email = email
         self.password = password
+        self.webhook = webhook
 
     @staticmethod
     def is_authenticated():

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -7,7 +7,7 @@
             </div>
             <div class="mdl-layout-spacer"></div>
             <nav class="mdl-navigation">
-                <a class="mdl-navigation__link t-white" href="subscribe">
+                <a class="mdl-navigation__link t-white" href="/subscribe">
                     <i class="material-icons md-36">exit_to_app</i>
                 </a>
                 <a class="mdl-navigation__link t-white" href="/settings">
@@ -21,18 +21,6 @@
             </nav>
         </div>
     </header>
-    {% if not subscriptions %} {% block jumbotron %}
-    <div class="jumbotron bg-white">
-        <div class="container">
-            <h2 class="t-centre">Welcome to Nanotify!</h2>
-            <p class="t-centre">
-                To begin, simply add a Nano address in the textbox below and subscribe. Once you have subscribed to the accounts you’re interested
-                in we immediately begin monitoring the Nano network for pending or received transactions sent to those accounts
-                you have subscribed to.
-            </p>
-        </div>
-    </div>
-    {% endblock %} {% endif %}
     <main class="mdl-layout__content">
         {% block content %}
         <div class="container">
@@ -49,13 +37,12 @@
                     <div class="row">
                         <div class="col"></div>
                         <div class="col-12">
-                            <form class="d-flex" action="subscribe" method="post">
-                                <input class="text-input" placeholder="e.g xrb_3gyoidb4mqb1qf6k8d7caddqfecnkcpe81cppizupwqxbz8fyu3eubp4rhqq" type="text"
-                                    name="account" />
-                                <input type="hidden" name="action" value="subscribe" />
+                            <form class="d-flex" action="settings" method="post">
+                                <input class="text-input" placeholder="e.g https://hooks.slack.com/services" type="text"
+                                    name="webhook" value="{{webhook if webhook else ''}}"/>
                                 <div class="p-8 m-4">
                                     <button type="submit" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect button-color-b-on-w" data-lpignore="true">
-                                        Subscribe
+                                        Add
                                     </button>
                                 </div>
                             </form>
@@ -64,33 +51,6 @@
                     </div>
                 </div>
                 <div class="col"></div>
-            </div>
-            <div class="row">
-                <div class="col-12 table-responsive">
-                    <table class="mdl-data-table mdl-js-data-table max-width m-auto m-t-20">
-                        <thead>
-                            <tr>
-                                <th class="mdl-data-table__cell--non-numeric">Account</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for subscription in subscriptions %}
-                            <tr>
-                                <td class="mdl-data-table__cell--non-numeric">{{ subscription.account }}</td>
-                                <td>
-                                    <form method="post">
-                                        <input hidden="hidden" name="account" value="{{ subscription.account }}">
-                                        <input type="hidden" name="action" value="delete">
-                                        <button type="submit" class="mdl-button mdl-js-button mdl-js-ripple-effect" data-lpignore="true">
-                                            <i class="material-icons">delete</i>
-                                        </button>
-                                    </form>
-                                </td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
             </div>
         </div>
         <div id="footer" class="container-fluid">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -21,6 +21,23 @@
             </nav>
         </div>
     </header>
+    {% if not webhook %} {% block jumbotron %}
+    <div class="jumbotron bg-white">
+        <div class="container">
+            <p class="t-centre">
+                Add a webhook like <a href="xrb_1niabkx3gbxit5j5yyqcpas71dkffggbr6zpd3heui8rpoocm5xqbdwq44oh">Slack</a> or integrate with your own apps.
+                <br>
+                The webhook comes in the comes in JSON form. e.g.
+                {
+                   "account":"xrb_1niabkx3gbxit5j5yyqcpas71dkffggbr6zpd3heui8rpoocm5xqbdwq44oh",
+                   "amount":10.94,
+                   "type":"received",
+                   "text":"Received 10.94 XRB at xrb_1niabkx3gbxit5j5yyqcpas71dkffggbr6zpd3heui8rpoocm5xqbdwq44oh"
+                }
+            </p>
+        </div>
+    </div>
+    {% endblock %} {% endif %}
     <main class="mdl-layout__content">
         {% block content %}
         <div class="container">
@@ -38,8 +55,9 @@
                         <div class="col"></div>
                         <div class="col-12">
                             <form class="d-flex" action="settings" method="post">
-                                <input class="text-input" placeholder="e.g https://hooks.slack.com/services" type="text"
+                                <input id="webhook" class="text-input" placeholder="Add a webhook e.g https://hooks.slack.com/services" type="text"
                                     name="webhook" value="{{webhook if webhook else ''}}"/>
+                                <div class="mdl-tooltip" data-mdl-for="webhook">Add a <strong>Webhook</strong> like Slack</div>
                                 <div class="p-8 m-4">
                                     <button type="submit" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect button-color-b-on-w" data-lpignore="true">
                                         Add

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -232,3 +232,7 @@ h1 {
 .max-width {
     width: 100%;
 }
+
+.md-36 {
+    font-size: 36px;
+}


### PR DESCRIPTION
Allow users to add webhooks for other notifications other than email

Testing
1. Run app with `pipenv install && pipenv run python run.py`
1. Create user
1. Login
1. Click new account icon
1. Save a webhook
1. Check it's saved